### PR TITLE
Sanitize error responses to prevent internal detail leakage

### DIFF
--- a/django_admin_mcp/handlers/actions.py
+++ b/django_admin_mcp/handlers/actions.py
@@ -18,6 +18,7 @@ from django_admin_mcp.handlers.base import (
     get_admin_form_class,
     json_response,
     normalize_fk_fields,
+    safe_error_message,
 )
 from django_admin_mcp.handlers.decorators import require_permission, require_registered_model
 from django_admin_mcp.protocol.types import TextContent
@@ -127,7 +128,7 @@ async def handle_actions(
             }
         )
     except (LookupError, AttributeError, TypeError) as e:
-        return json_response({"error": str(e)})
+        return json_response({"error": safe_error_message(e)})
 
 
 @require_registered_model
@@ -204,7 +205,7 @@ async def handle_action(
         result = await execute_action()
         return json_response(result)
     except Exception as e:
-        return json_response({"error": str(e)})
+        return json_response({"error": safe_error_message(e)})
 
 
 def _get_bulk_user(request):
@@ -268,7 +269,7 @@ async def handle_bulk_create(
                     _log_action(user=user, obj=obj, action_flag=ADDITION, change_message="Bulk created via MCP")
                 results["success"].append({"index": i, "id": obj.pk, "created": True})
             except Exception as e:
-                results["errors"].append({"index": i, "error": str(e)})
+                results["errors"].append({"index": i, "error": safe_error_message(e)})
 
         return items, results
 
@@ -341,7 +342,7 @@ async def handle_bulk_update(
             except model.DoesNotExist:
                 results["errors"].append({"index": i, "error": f"Object with id {obj_id} not found"})
             except Exception as e:
-                results["errors"].append({"index": i, "error": str(e)})
+                results["errors"].append({"index": i, "error": safe_error_message(e)})
 
         return items, results
 
@@ -380,7 +381,7 @@ async def handle_bulk_delete(
             except model.DoesNotExist:
                 results["errors"].append({"index": i, "error": f"Object with id {obj_id} not found"})
             except Exception as e:
-                results["errors"].append({"index": i, "error": str(e)})
+                results["errors"].append({"index": i, "error": safe_error_message(e)})
 
         return items, results
 

--- a/django_admin_mcp/handlers/crud.py
+++ b/django_admin_mcp/handlers/crud.py
@@ -21,6 +21,7 @@ from django_admin_mcp.handlers.base import (
     get_admin_form_class,
     json_response,
     normalize_fk_fields,
+    safe_error_message,
     serialize_instance,
 )
 from django_admin_mcp.handlers.decorators import require_permission, require_registered_model
@@ -311,7 +312,7 @@ def _update_inlines(
                     {
                         "model": inline_model_name,
                         "id": item.get("id"),
-                        "error": str(e),
+                        "error": safe_error_message(e),
                     }
                 )
 
@@ -427,7 +428,7 @@ async def handle_list(
 
         return [TextContent(text=response.model_dump_json(indent=2))]
     except Exception as e:
-        return json_response({"error": str(e)})
+        return json_response({"error": safe_error_message(e)})
 
 
 @require_registered_model
@@ -496,7 +497,7 @@ async def handle_get(
     except model.DoesNotExist:  # type: ignore[attr-defined]
         return json_response({"error": f"{model_name} not found"})
     except Exception as e:
-        return json_response({"error": str(e)})
+        return json_response({"error": safe_error_message(e)})
 
 
 @require_registered_model
@@ -583,7 +584,7 @@ async def handle_create(
 
         return [TextContent(text=response.model_dump_json(indent=2))]
     except Exception as e:
-        return json_response({"error": str(e)})
+        return json_response({"error": safe_error_message(e)})
 
 
 @require_registered_model
@@ -714,7 +715,7 @@ async def handle_update(
     except model.DoesNotExist:  # type: ignore[attr-defined]
         return json_response({"error": f"{model_name} not found"})
     except Exception as e:
-        return json_response({"error": str(e)})
+        return json_response({"error": safe_error_message(e)})
 
 
 @require_registered_model
@@ -778,4 +779,4 @@ async def handle_delete(
     except model.DoesNotExist:  # type: ignore[attr-defined]
         return json_response({"error": f"{model_name} not found"})
     except Exception as e:
-        return json_response({"error": str(e)})
+        return json_response({"error": safe_error_message(e)})

--- a/django_admin_mcp/handlers/meta.py
+++ b/django_admin_mcp/handlers/meta.py
@@ -14,6 +14,7 @@ from django.http import HttpRequest
 from django_admin_mcp.handlers.base import (
     async_check_permission,
     json_response,
+    safe_error_message,
 )
 from django_admin_mcp.handlers.decorators import require_permission, require_registered_model
 from django_admin_mcp.protocol.types import TextContent
@@ -199,7 +200,7 @@ async def handle_describe(
 
         return json_response(result)
     except Exception as e:
-        return json_response({"error": str(e)})
+        return json_response({"error": safe_error_message(e)})
 
 
 async def handle_find_models(
@@ -277,4 +278,4 @@ async def handle_find_models(
             }
         )
     except Exception as e:
-        return json_response({"error": str(e)})
+        return json_response({"error": safe_error_message(e)})

--- a/django_admin_mcp/handlers/relations.py
+++ b/django_admin_mcp/handlers/relations.py
@@ -13,6 +13,7 @@ from django.http import HttpRequest
 
 from django_admin_mcp.handlers.base import (
     json_response,
+    safe_error_message,
     serialize_instance,
 )
 from django_admin_mcp.handlers.decorators import require_permission, require_registered_model
@@ -304,4 +305,4 @@ async def handle_autocomplete(
         result = await search_autocomplete()
         return json_response(result)
     except Exception as e:
-        return json_response({"error": str(e)})
+        return json_response({"error": safe_error_message(e)})


### PR DESCRIPTION
## Summary
- Add `safe_error_message()` utility that maps known Django exception types (IntegrityError, FieldError, OperationalError, ValidationError, ValueError, TypeError) to generic client-safe messages while logging the real exception server-side
- Replace all 16 instances of raw `str(e)` in handler error responses across `crud.py`, `actions.py`, `relations.py`, and `meta.py`
- Add `sanitize_pydantic_errors()` to strip `input`, `ctx`, and `url` fields from Pydantic validation errors in `views.py`
- Add 11 new tests verifying that each exception type returns its safe message, real exceptions are logged, and Pydantic error sanitization works correctly

## What could leak before this fix
- `IntegrityError` → table/column names, constraint names
- `FieldError` → valid field names and model schema
- `OperationalError` → database host/connection info
- `FileNotFoundError` → internal file paths
- Pydantic `e.errors()` → internal field types, input values, context

## Test plan
- [x] All 372 tests pass (361 existing + 11 new)
- [x] `safe_error_message` maps each exception type to its generic message
- [x] Real exception details are logged via `logger.exception()`
- [x] `sanitize_pydantic_errors` strips `input`, `ctx`, `url` fields
- [x] No raw `str(e)` or unsanitized `e.errors()` remain in source
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy, djlint)