### PR TITLE
Fix URL path duplication when mounting at custom path

### DIFF
--- a/django_admin_mcp/urls.py
+++ b/django_admin_mcp/urls.py
@@ -9,6 +9,6 @@ from django_admin_mcp import views
 app_name = "django_admin_mcp"
 
 urlpatterns = [
-    path("mcp/", views.mcp_endpoint, name="mcp_endpoint"),
+    path("", views.mcp_endpoint, name="mcp_endpoint"),
     path("health/", views.mcp_health, name="health"),
 ]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- URL path duplication when mounting at custom path (e.g., `path("mcp/", ...)` produced `/mcp/mcp/` instead of `/mcp/`) ([#68](https://github.com/7tg/django-admin-mcp/issues/68))
+
 ### Added
 - Comprehensive MkDocs Material documentation
 - Getting started guides

--- a/example/example_project/urls.py
+++ b/example/example_project/urls.py
@@ -6,5 +6,5 @@ from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/', include('django_admin_mcp.urls')),
+    path('api/mcp/', include('django_admin_mcp.urls')),
 ]

--- a/tests/http/test_edge_cases.py
+++ b/tests/http/test_edge_cases.py
@@ -36,7 +36,7 @@ class TestEmptyToolResult:
 
             client = AsyncClient()
             response = await client.post(
-                "/api/mcp/",
+                "/api/",
                 data=json.dumps({"method": "tools/call", "params": {"name": "test_tool", "arguments": {}}}),
                 content_type="application/json",
                 headers={"Authorization": f"Bearer {token.plaintext_token}"},
@@ -59,7 +59,7 @@ class TestFunctionBasedViewEdgeCases:
         client = AsyncClient()
 
         # Try GET request
-        response = await client.get("/api/mcp/")
+        response = await client.get("/api/")
         assert response.status_code == 405
         data = json.loads(response.content)
         assert "error" in data
@@ -74,7 +74,7 @@ class TestFunctionBasedViewEdgeCases:
 
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data="invalid json {",
             content_type="application/json",
             headers={"Authorization": f"Bearer {token.plaintext_token}"},
@@ -94,7 +94,7 @@ class TestFunctionBasedViewEdgeCases:
 
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps({"method": "unknown/method"}),
             content_type="application/json",
             headers={"Authorization": f"Bearer {token.plaintext_token}"},
@@ -114,7 +114,7 @@ class TestFunctionBasedViewEdgeCases:
 
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps(
                 {
                     "method": "tools/call",
@@ -141,7 +141,7 @@ class TestFunctionBasedViewEdgeCases:
 
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps({"method": "tools/call", "params": {"name": "find_models", "arguments": {}}}),
             content_type="application/json",
             headers={"Authorization": f"Bearer {token.plaintext_token}"},

--- a/tests/http/test_endpoints.py
+++ b/tests/http/test_endpoints.py
@@ -37,7 +37,7 @@ class TestHTTPInterface:
         """Test MCP endpoint rejects requests without token."""
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps({"method": "tools/list"}),
             content_type="application/json",
         )
@@ -52,7 +52,7 @@ class TestHTTPInterface:
         """Test MCP endpoint rejects requests with invalid token."""
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps({"method": "tools/list"}),
             content_type="application/json",
             headers={"Authorization": "Bearer invalid-token"},
@@ -71,7 +71,7 @@ class TestHTTPInterface:
 
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps({"method": "tools/list"}),
             content_type="application/json",
             headers={"Authorization": f"Bearer {token.plaintext_token}"},
@@ -99,7 +99,7 @@ class TestHTTPInterface:
 
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps({"method": "tools/list"}),
             content_type="application/json",
             headers={"Authorization": f"Bearer {token.plaintext_token}"},
@@ -119,7 +119,7 @@ class TestHTTPInterface:
 
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps({"method": "tools/list"}),
             content_type="application/json",
             headers={"Authorization": f"Bearer {token.plaintext_token}"},

--- a/tests/http/test_token.py
+++ b/tests/http/test_token.py
@@ -86,7 +86,7 @@ class TestMCPToken:
 
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps({"method": "tools/list"}),
             content_type="application/json",
             headers={"Authorization": f"Bearer {token.plaintext_token}"},
@@ -122,7 +122,7 @@ class TestMCPExpose:
 
             client = AsyncClient()
             response = await client.post(
-                "/api/mcp/",
+                "/api/",
                 data=json.dumps({"method": "tools/list"}),
                 content_type="application/json",
                 headers={"Authorization": f"Bearer {token.plaintext_token}"},

--- a/tests/http/test_url_patterns.py
+++ b/tests/http/test_url_patterns.py
@@ -1,0 +1,41 @@
+"""
+Tests for URL pattern configuration.
+
+Verifies that django_admin_mcp.urls does not include a prefix,
+allowing users to control the mount point entirely.
+See: https://github.com/7tg/django-admin-mcp/issues/68
+"""
+
+from django.urls import resolve, reverse
+
+
+class TestURLPatterns:
+    """Test that URL patterns follow Django conventions."""
+
+    def test_mcp_endpoint_no_path_duplication(self):
+        """URLs should not duplicate path when mounted at a custom prefix.
+
+        When mounting at path("mcp/", include("django_admin_mcp.urls")),
+        the endpoint should be at /mcp/, not /mcp/mcp/.
+        """
+        url = reverse("django_admin_mcp:mcp_endpoint")
+        # tests/urls.py mounts at "api/", so the URL should be /api/
+        # not /api/mcp/ (which would indicate an internal mcp/ prefix)
+        assert url == "/api/"
+
+    def test_health_endpoint_path(self):
+        """Health endpoint should be at mount_point/health/."""
+        url = reverse("django_admin_mcp:health")
+        assert url == "/api/health/"
+
+    def test_mcp_endpoint_resolves(self):
+        """The MCP endpoint should resolve at the mount point root."""
+        match = resolve("/api/")
+        assert match.url_name == "mcp_endpoint"
+        assert match.namespace == "django_admin_mcp"
+
+    def test_health_endpoint_resolves(self):
+        """The health endpoint should resolve at mount_point/health/."""
+        match = resolve("/api/health/")
+        assert match.url_name == "health"
+        assert match.namespace == "django_admin_mcp"

--- a/tests/http/test_validation.py
+++ b/tests/http/test_validation.py
@@ -30,7 +30,7 @@ class TestPydanticValidation:
 
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps({"method": "invalid/method"}),
             content_type="application/json",
             headers={"Authorization": f"Bearer {token.plaintext_token}"},
@@ -49,7 +49,7 @@ class TestPydanticValidation:
 
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps({"method": "tools/call"}),
             content_type="application/json",
             headers={"Authorization": f"Bearer {token.plaintext_token}"},
@@ -72,7 +72,7 @@ class TestPydanticValidation:
 
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps(
                 {"method": "tools/call", "params": {"name": "find_models", "arguments": {"query": "article"}}}
             ),
@@ -94,7 +94,7 @@ class TestPydanticValidation:
 
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps({"method": "tools/call", "params": {"name": "find_models"}}),
             content_type="application/json",
             headers={"Authorization": f"Bearer {token.plaintext_token}"},
@@ -114,7 +114,7 @@ class TestPydanticValidation:
 
         client = AsyncClient()
         response = await client.post(
-            "/api/mcp/",
+            "/api/",
             data=json.dumps({"method": "tools/list", "extra_field": "should be ignored"}),
             content_type="application/json",
             headers={"Authorization": f"Bearer {token.plaintext_token}"},


### PR DESCRIPTION
## Summary

- Remove internal `mcp/` prefix from `django_admin_mcp/urls.py` so users fully control the mount point, following standard Django URL conventions
- Previously, `path("mcp/", include("django_admin_mcp.urls"))` produced `/mcp/mcp/` instead of `/mcp/`
- Add URL pattern tests to prevent regression

Closes #68

## Test plan

- [x] New `test_url_patterns.py` verifies no path duplication via `reverse()` and `resolve()`
- [x] All 382 tests pass (378 existing + 4 new)
- [x] Ruff lint clean
- [x] Pre-commit hooks pass