### PR TITLE
Fix actions listed but not executable via action_ tool

### DIFF
--- a/django_admin_mcp/handlers/base.py
+++ b/django_admin_mcp/handlers/base.py
@@ -40,7 +40,7 @@ class MCPRequest(HttpRequest):
         self.user = user
         self.method = "GET"
         self.path = "/"
-        self.META = {}
+        self.META = {"SCRIPT_NAME": ""}
         self.GET = {}
         self.POST = {}
 


### PR DESCRIPTION
## Summary

- **Fixes #69** — actions listed by `actions_<model>` returned "not found" when executing via `action_<model>`
- Root cause: `handle_action` iterated raw `model_admin.actions` and checked `callable(action)`, which skipped string-referenced method actions (a standard Django pattern like `actions = ["set_status_disabled"]`)
- Replaced manual action iteration with Django's `ModelAdmin.get_actions(request)` which properly resolves string references, includes globally-registered actions, and filters by user permissions

## Test plan

- [x] New test `test_listed_string_action_can_be_executed` reproduces the exact bug from the issue (string-referenced action listed but not executable)
- [x] All 379 tests pass (378 existing + 1 new)
- [x] Lint clean (`ruff check`, `ruff-format`, `mypy` all pass)